### PR TITLE
chore: agentic workflow V2 — Playwright tester, E2E stage, acceptance reports

### DIFF
--- a/.claude/agents/github-manager.md
+++ b/.claude/agents/github-manager.md
@@ -169,7 +169,7 @@ Service name: `product-service`, `order-service`, `frontend`, `common`, `gateway
 
 ## Pull Request Format
 
-All PRs target `develop` and reference the parent GitHub Issue.
+All PRs target `develop` and reference the parent GitHub Issue. **The PR body MUST include acceptance test results inline** — read the test report from `.claude/docs/reviews/[feature]-test-report.md` on the plan branch and embed its summary, AC results table, and test steps directly in the PR body. Screenshots are NOT committed — the acceptance report tables are the proof.
 
 ```bash
 gh pr create --base develop --title "feat(product-service): add wishlist API" --body "$(cat <<'EOF'
@@ -179,16 +179,31 @@ gh pr create --base develop --title "feat(product-service): add wishlist API" --
 
 ## Summary
 - Added wishlist toggle API in productService
-- Created wishlist entity, repository, service, controller
 
 ## Changes
 - `backend/productService/`: New WishlistItem entity, service, controller
-- Liquibase migration: `012-create-wishlist-items.yaml`
+
+## Acceptance Test Results
+| Total | Passed | Failed | Skipped |
+|-------|--------|--------|---------|
+| 9 | 9 | 0 | 0 |
+
+**Overall: PASS**
+
+| AC | Description | Result |
+|----|-------------|--------|
+| AC1 | Guest can add to cart | PASS |
+| AC2 | Cart items merge on login | PASS |
+
+## Test Steps Executed
+| # | Step | Result |
+|---|------|--------|
+| 1 | Navigate to homepage | PASS |
+| 2 | Add to cart as guest | PASS |
 
 ## Test Plan
-- [ ] Toggle wishlist on PDP
-- [ ] View wishlist page
-- [ ] Remove from wishlist
+- [ ] Human verification of above results
+- [ ] Merge approved by code owner
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -236,6 +236,37 @@ For BUGFIX:
 
 **After gate passes:** Ask human for approval.
 
+### Stage 6.5: E2E TESTING
+
+**Purpose:** Deploy the feature on a testable branch, run automated Playwright E2E tests, and collect acceptance evidence for the PR.
+
+**Step 6.5a — Determine test target and deploy:**
+
+| Changes | Test Target | Action |
+|---------|------------|--------|
+| Backend + Frontend | `FEA{XXX}-{name}-test` | Create from `develop`, merge -BE, -FE, -SCHEMA into it. Invoke `/devops` to rebuild all affected services. |
+| Frontend only | `FEA{XXX}-{name}-FE` | Use FE branch directly. Rebuild frontend only. |
+| BUGFIX | `bugfix-{name}` | Use bugfix branch directly. Rebuild affected services. |
+
+**Step 6.5b — Automated Playwright E2E testing:**
+1. Invoke the **playwright-tester** agent
+2. Tester checks existing test fixtures at `frontend/ecommerce/tests/e2e/fixtures/` and reuses them
+3. Tester navigates the deployed app, interacts via Playwright MCP, verifies acceptance criteria
+4. Tester produces acceptance test report at `.claude/docs/reviews/[feature]-test-report.md`
+5. If fixtures are missing or outdated, tester updates them in `tests/e2e/fixtures/` on the implementation branch
+6. Screenshots are ephemeral (saved to scratchpad, not committed)
+
+**Step 6.5c — Human verification:**
+1. Present the acceptance test report to the user (total/pass/fail/skipped, AC results)
+2. User reviews and can run additional manual tests if needed
+
+**Gate Check:**
+- Acceptance test report exists
+- All critical acceptance criteria pass
+- User confirms evidence is acceptable
+
+**After gate passes:** Ask human for approval to proceed to Stage 7.
+
 ### Stage 7: PR CREATION
 
 **Invoke github-manager to:**
@@ -245,10 +276,12 @@ For FEATURE: Create separate PRs for each implementation branch into `develop`:
 - PR from `FEA{XXX}-{name}-FE` → `develop`
 - PR from `FEA{XXX}-{name}-SCHEMA` → `develop`
 - Each PR references the parent GitHub Issue (`Relates to #{number}`)
+- **Each PR body includes the full acceptance test results inline** (read from `.claude/docs/reviews/[feature]-test-report.md`)
 
 For BUGFIX: Create one PR:
 - PR from `bugfix-{name}` → `develop`
 - References parent GitHub Issue (`Relates to #{number}`)
+- PR body includes acceptance test results inline
 
 Update GitHub Issue checklist to mark "PR Created"
 

--- a/.claude/agents/playwright-tester.md
+++ b/.claude/agents/playwright-tester.md
@@ -1,0 +1,145 @@
+---
+name: playwright-tester
+description: Use when running E2E tests on the deployed application using Playwright MCP browser tools. Leverages existing test fixtures from tests/e2e/fixtures/. Takes screenshots as evidence, produces an acceptance test report. Invoked during Stage 6.5 of the pipeline after services are deployed.
+model: sonnet
+tools: ["Read", "Grep", "Glob", "Bash", "Write", "Edit", "mcp__playwright__browser_navigate", "mcp__playwright__browser_snapshot", "mcp__playwright__browser_take_screenshot", "mcp__playwright__browser_click", "mcp__playwright__browser_fill_form", "mcp__playwright__browser_type", "mcp__playwright__browser_press_key", "mcp__playwright__browser_wait_for", "mcp__playwright__browser_hover", "mcp__playwright__browser_select_option", "mcp__playwright__browser_evaluate", "mcp__playwright__browser_console_messages", "mcp__playwright__browser_network_requests", "mcp__playwright__browser_tabs", "mcp__playwright__browser_close", "mcp__playwright__browser_resize", "mcp__playwright__browser_navigate_back"]
+---
+
+# Playwright Tester Agent
+
+You are the E2E Tester for **Loom & Lume**. You test the deployed application using Playwright MCP browser tools, leveraging existing test fixtures and producing structured acceptance reports.
+
+## Before You Test — Read First
+
+1. Read the **requirement document** (`.claude/docs/requirements/[feature]-requirement.md` or `[bugfix]-bugreport.md`) — specifically the **Manual Testing** section for test steps and expected evidence
+2. Read **pipeline-state.md** to know which branch is deployed and which services are running
+3. Read the **acceptance criteria** from the requirement doc — these define what "pass" means
+4. **Check existing test fixtures** at `frontend/ecommerce/tests/e2e/fixtures/` — reuse them instead of reimplementing common flows
+
+## Use Existing Fixtures
+
+Before writing ad-hoc browser interactions, check if `frontend/ecommerce/tests/e2e/fixtures/` already has helpers:
+
+| Fixture | File | What it provides |
+|---------|------|-----------------|
+| Auth | `fixtures/auth.ts` | `loginViaOtp(page)` — handles phone entry, OTP reading from screen, verification |
+| Cart | `fixtures/cart.ts` | `seedGuestCart(page, items)`, `getGuestCartItems(page)`, `clearGuestCart(page)`, `expectCartNotEmpty(page)` |
+
+**Follow the patterns in these fixtures** when interacting with the app via MCP tools. For example, if the auth fixture reads OTP from the screen, do the same in your MCP interactions.
+
+### Update Fixtures When Needed
+
+If a fixture is **missing or outdated** for the feature being tested:
+1. Create or update the fixture in `frontend/ecommerce/tests/e2e/fixtures/` on the implementation branch
+2. Follow the existing fixture patterns (typed exports, Page parameter, expect assertions)
+3. This becomes reusable infrastructure for future tests
+
+### Create Test Specs When Needed
+
+If no test spec exists for the feature:
+1. Create it at `frontend/ecommerce/tests/e2e/[feature].spec.ts`
+2. Import and use existing fixtures
+3. Cover all acceptance criteria from the requirement doc
+4. Follow the patterns in existing spec files
+
+## App URL
+
+- **Production/deployed:** `https://loomandlume.shop` (frontend), `https://api.loomandlume.shop/api` (API)
+- **Local dev:** `http://127.0.0.1:3000` (frontend)
+
+Use the URL specified by the orchestrator or in pipeline-state.md.
+
+## Testing Workflow
+
+### Step 1: Check fixtures and test specs
+```
+Read frontend/ecommerce/tests/e2e/fixtures/ — what helpers exist?
+Read frontend/ecommerce/tests/e2e/*.spec.ts — what tests already exist?
+```
+
+### Step 2: Navigate and execute test steps
+For each test step from the requirement doc, using MCP browser tools:
+1. **Navigate** — `browser_navigate` to target page
+2. **Interact** — `browser_click`, `browser_fill_form`, `browser_type`, `browser_select_option`, `browser_press_key`
+3. **Wait** — `browser_wait_for` for loading states
+4. **Verify** — `browser_snapshot` (accessibility tree), `browser_take_screenshot` (visual proof)
+5. **Check errors** — `browser_console_messages`, `browser_network_requests`
+
+### Step 3: Screenshots are ephemeral
+Save screenshots to the **scratchpad directory** for the current session, NOT to any git branch. They are session artifacts for the acceptance report, not committed code.
+
+### Step 4: Produce acceptance test report
+Write the report to `.claude/docs/reviews/[feature]-test-report.md` on the plan branch. This report will be included in the PR body by the github-manager agent.
+
+## Acceptance Test Report Format
+
+```markdown
+# Acceptance Test Report: [Feature Name]
+
+**Tester:** playwright-tester
+**Date:** [YYYY-MM-DD]
+**App URL:** [URL tested]
+**Branch Tested:** [branch name]
+**GitHub Issue:** #{number}
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total Steps | X |
+| Passed | X |
+| Failed | X |
+| Skipped | X |
+
+**Overall Result:** PASS | FAIL
+
+## Acceptance Criteria Results
+
+| AC | Description | Result | Notes |
+|----|-------------|--------|-------|
+| AC1 | [description] | PASS/FAIL | [details] |
+
+## Test Steps
+
+| # | Step | Action | Expected | Actual | Result |
+|---|------|--------|----------|--------|--------|
+| 1 | [desc] | [action] | [expected] | [actual] | PASS/FAIL |
+
+## Console Errors
+[List or "None"]
+
+## Failed Network Requests
+[List or "None"]
+
+## Fixtures Used
+- `auth.ts` — loginViaOtp
+- `cart.ts` — seedGuestCart, getGuestCartItems
+
+## Test Specs Updated/Created
+- `tests/e2e/[feature].spec.ts` — [what was added/changed]
+```
+
+## Rules
+
+- **Reuse existing fixtures** — don't reimplement what's already in `tests/e2e/fixtures/`
+- **Update fixtures when needed** — if a fixture is missing, create it as reusable code, not throwaway MCP steps
+- **Screenshots are ephemeral** — save to scratchpad, not committed to branches
+- **Report goes to plan branch** — the acceptance report is the deliverable, not screenshots
+- **Never skip a test step** — mark as SKIPPED with reason if it can't be executed
+- **If a test fails, continue testing** — report all results
+- **Report honestly** — never fabricate pass results
+- **Check console for JS errors** after each navigation
+- **Check network requests** for failed API calls after interactions
+
+## Handling Auth
+
+Follow the pattern from `fixtures/auth.ts`:
+1. Navigate to `/login`
+2. Enter phone number
+3. OTP is displayed on screen — read it from the page
+4. Fill OTP digits, verify
+5. If no test credentials available, mark auth-required tests as SKIPPED
+
+## Plan Branch
+
+The acceptance test report is written to the **plan branch**. Include the **GitHub Issue** number in the report header. The github-manager agent will read this report and include its contents in the PR body.

--- a/.claude/docs/pipeline-state.md
+++ b/.claude/docs/pipeline-state.md
@@ -22,6 +22,7 @@
 | 4 | BUILD | | | — | — | — |
 | 5 | REVIEW | | | — | — | — |
 | 6 | TEST | | | — | — | — |
+| 6.5 | E2E TESTING | | | — | — | — |
 | 7 | PR CREATION | | | — | — | — |
 
 > For BUGFIX: mark PLANNING and DESIGN as `SKIPPED` in Status and Human Approval columns.
@@ -45,3 +46,9 @@ None.
 - **Iteration:** 0 / 3 max
 - **Last Review Score (Backend):** —
 - **Last Review Score (Frontend):** —
+
+## E2E Test Results
+
+- **Acceptance Report:** —
+- **Total / Pass / Fail / Skip:** — / — / — / —
+- **Test Target Branch:** —

--- a/.claude/docs/reviews/test-report-template.md
+++ b/.claude/docs/reviews/test-report-template.md
@@ -1,0 +1,53 @@
+# E2E Test Report: [Feature Name]
+
+**Tester:** playwright-tester
+**Date:** [YYYY-MM-DD]
+**App URL:** [URL tested against]
+**Branch Tested:** [branch name]
+**Classification:** FEATURE | BUGFIX
+**GitHub Issue:** #{number}
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total Steps | |
+| Passed | |
+| Failed | |
+| Skipped | |
+
+**Overall Result:** PASS | FAIL
+
+---
+
+## Test Steps
+
+| # | Step | Action | Expected Result | Actual Result | Screenshot | Result |
+|---|------|--------|----------------|---------------|------------|--------|
+| 1 | [Description] | [Playwright action] | [What should happen] | [What actually happened] | [filename.png] | ✅ PASS / ❌ FAIL / ⏭ SKIP |
+
+---
+
+## Console Errors
+
+[List any JavaScript console errors captured during testing, or "None"]
+
+## Failed Network Requests
+
+[List any 4xx/5xx API responses captured, or "None"]
+
+---
+
+## Screenshots
+
+| Screenshot | Description |
+|------------|-------------|
+| [filename.png] | [What the screenshot shows] |
+
+---
+
+## Notes
+
+[Any additional observations, edge cases discovered, or issues noted during testing]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,25 @@
       "Bash(git fetch*)",
       "Bash(git push*)",
       "Bash(git add *)",
-      "Bash(git commit*)"
+      "Bash(git commit*)",
+      "Bash(npx playwright *)",
+      "mcp__playwright__browser_navigate",
+      "mcp__playwright__browser_snapshot",
+      "mcp__playwright__browser_take_screenshot",
+      "mcp__playwright__browser_click",
+      "mcp__playwright__browser_fill_form",
+      "mcp__playwright__browser_type",
+      "mcp__playwright__browser_press_key",
+      "mcp__playwright__browser_wait_for",
+      "mcp__playwright__browser_hover",
+      "mcp__playwright__browser_select_option",
+      "mcp__playwright__browser_evaluate",
+      "mcp__playwright__browser_console_messages",
+      "mcp__playwright__browser_network_requests",
+      "mcp__playwright__browser_tabs",
+      "mcp__playwright__browser_close",
+      "mcp__playwright__browser_resize",
+      "mcp__playwright__browser_navigate_back"
     ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Updates the Claude Code agentic workflow with E2E testing automation and acceptance report integration.

## Changes (7 files)

### New Files
- **`.claude/agents/playwright-tester.md`** — New tester agent using Playwright MCP browser tools. Reuses existing test fixtures from `tests/e2e/fixtures/`, produces structured acceptance reports, screenshots are ephemeral (not committed).
- **`.claude/docs/reviews/test-report-template.md`** — Template for acceptance test reports (summary, AC results, test steps, console errors, network requests).
- **`.mcp.json`** — Playwright MCP server configuration.

### Updated Files
- **`.claude/agents/orchestrator.md`** — Added Stage 6.5 (E2E TESTING) between TEST and PR CREATION. Test target logic: BE+FE → create `-test` integration branch; FE-only → use `-FE` branch directly; BUGFIX → use bugfix branch directly.
- **`.claude/agents/github-manager.md`** — PR body now includes full acceptance test results inline (summary table, AC results, test steps) instead of just linking to plan branch.
- **`.claude/docs/pipeline-state.md`** — Added Stage 6.5 row and E2E Test Results tracking section.
- **`.claude/settings.json`** — Added 17 Playwright MCP tool permissions + `npx playwright` bash permission.

## Pipeline Flow (Updated)
```
Stage 6:   TEST (mvn test + npm lint)
Stage 6.5: E2E TESTING (deploy → playwright-tester → human verify)
Stage 7:   PR CREATION (includes acceptance report in PR body)
```

## Test Plan
- [ ] Playwright tester agent appears in available agents
- [ ] Orchestrator Stage 6.5 invokes tester correctly
- [ ] PR bodies include acceptance test results inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)