### PR TITLE
fix: OTP login fails on first attempt with guest cart items

### DIFF
--- a/frontend/ecommerce/src/app/(authentication)/otp/page.tsx
+++ b/frontend/ecommerce/src/app/(authentication)/otp/page.tsx
@@ -8,14 +8,10 @@ import { requestOtp } from "../actions";
 import { notify } from "@/utils/helperFunctions";
 import { apiFetch } from "@/lib/apiFetch";
 import { IconDeviceMobileMessage, IconEdit } from "@tabler/icons-react";
-import { ErrorResponse, VerifyOtpResponse } from "@/constants/types";
+import { CartItemDTO, ErrorResponse, VerifyOtpResponse } from "@/constants/types";
 import { useAuthActions } from "@/utils/store/auth";
 import { useResendTimer } from "@/utils/hooks/useResendTimer";
 import { useCartActions, useCartStore } from "@/utils/store/cart";
-import {
-    getCartItemsAction,
-    mergeGuestCartAction,
-} from "@/app/(customer-checkout)/checkout/cartActions";
 
 // Module-level one-shot guard to prevent re-entrant double-merge on rapid
 // double submit. Overwrite semantics (D1) make a re-merge harmless, but this
@@ -73,8 +69,20 @@ const Otp = () => {
         if (mergeInFlight) return;
         mergeInFlight = true;
         try {
-            await mergeGuestCartAction(guestItems); // POST /merge
-            const serverItems = await getCartItemsAction(); // authoritative merged cart
+            // Use client-side apiFetch (credentials: "include") instead of server
+            // actions — right after OTP verification the auth cookies are in the
+            // browser but not yet available in the Next.js server-action request context.
+            const payload = guestItems.map((ci) => ({
+                productItemId: ci.productItemId,
+                quantity: ci.quantity,
+                priceSnapshot: ci.priceSnapshot,
+                isSelected: ci.isSelected ?? true,
+            }));
+            await apiFetch<void>("/cart-service/cart-items/merge", {
+                method: "POST",
+                body: payload,
+            });
+            const serverItems = await apiFetch<CartItemDTO[]>("/cart-service/cart-items");
             setCartItems(serverItems ?? []); // AC4: replace guest cart with server cart
         } catch {
             notify({


### PR DESCRIPTION
## Summary

- Fixed a race condition where guest cart merge after OTP login used server actions (`serverApiFetch` → `await cookies()`), but auth cookies weren't yet available in the Next.js server-action request context — causing a 401 that killed the login flow on the first attempt
- Replaced server action calls with direct client-side `apiFetch` calls which use `credentials: "include"` and automatically send the freshly set browser cookies
- Login with guest cart items now succeeds on the first OTP attempt

Closes #29

## Test plan

- [x] Add items to cart as a guest user
- [x] Navigate to login, enter phone number, receive OTP
- [x] Enter OTP — verify login succeeds on **first attempt**
- [x] Verify guest cart items are merged into the authenticated cart
- [x] Verify login without guest cart items still works as before
- [x] Verify login with empty guest cart still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)