### PR TITLE
fix: enable price summary fetch for guest cart users

### DIFF
--- a/frontend/ecommerce/src/(components)/LoginComponent/index.tsx
+++ b/frontend/ecommerce/src/(components)/LoginComponent/index.tsx
@@ -16,8 +16,8 @@ const LoginComponent = ({
   LoggedInComponent,
   NotLoggedInComponent,
 }: {
-  LoggedInComponent: any;
-  NotLoggedInComponent: any;
+  LoggedInComponent: React.ReactNode;
+  NotLoggedInComponent: React.ReactNode;
 }) => {
   const user = useUserInfo();
   const router = useRouter();

--- a/frontend/ecommerce/src/(components)/productCard/ProductCardImageSection.tsx
+++ b/frontend/ecommerce/src/(components)/productCard/ProductCardImageSection.tsx
@@ -34,7 +34,7 @@ export default function ProductCardImageSection({ images, inStock = true, imgSiz
                     } as React.CSSProperties
                 }>
                     <div className="css-carousel-track">
-                        {carouselImages.map((img: any) => (
+                        {carouselImages.map((img: { imgUrl: string }) => (
                             <div className="css-carousel-slide" key={img.imgUrl}>
                                 <Image
                                     src={img.imgUrl}

--- a/frontend/ecommerce/src/app/(authentication)/setup-account/page.tsx
+++ b/frontend/ecommerce/src/app/(authentication)/setup-account/page.tsx
@@ -22,7 +22,7 @@ const SetUpAccount = () => {
             </Stack>
             <Stack gap={12}>
                 <UpdateProfileForm userInfodata={userInfoData} redirecturl={redirecturl} />
-                <Text c={"primaryDark.7"} style={{ cursor: 'pointer' }} size='sm' fw={600} onClick={handleSkip}>Skip for now, I'll do it later</Text>
+                <Text c={"primaryDark.7"} style={{ cursor: 'pointer' }} size='sm' fw={600} onClick={handleSkip}>Skip for now, I&apos;ll do it later</Text>
             </Stack>
         </Stack>
     )

--- a/frontend/ecommerce/src/app/(customer)/(authenticated)/create-checkout-session/page.tsx
+++ b/frontend/ecommerce/src/app/(customer)/(authenticated)/create-checkout-session/page.tsx
@@ -65,7 +65,8 @@ const CreateCheckoutSession = () => {
       return;
     }
 
-    const options: any = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const options: Record<string, any> = {
       key,
       amount: orderData.amount * 100, // paise
       currency: "INR",
@@ -76,7 +77,7 @@ const CreateCheckoutSession = () => {
         name: user?.fullName || "",
         email: user?.emailId || "",
       },
-      handler: function (response: any) {
+      handler: function () {
         verifyingPayment.current = true;
         setLoaderMsg("Payment received. Confirming with server...");
         startPolling(orderId!);
@@ -99,7 +100,7 @@ const CreateCheckoutSession = () => {
         color: "#3399cc",
       },
     };
-    const paymentObject = new (window as any).Razorpay(options);
+    const paymentObject = new (window as unknown as { Razorpay: new (opts: Record<string, unknown>) => { open: () => void } }).Razorpay(options);
     paymentObject.open();
   };
 

--- a/frontend/ecommerce/src/app/(customer)/(authenticated)/my-profile/edit/UpdateEmail.tsx
+++ b/frontend/ecommerce/src/app/(customer)/(authenticated)/my-profile/edit/UpdateEmail.tsx
@@ -115,7 +115,7 @@ const UpdateEmail = ({ setFormEmailValue, currEmail }: { setFormEmailValue: (val
                 {!isOtpStep ?
                     <Stack>
                         <Text size='sm' c='dimmed'>
-                            We'll send an otp to this address for verification purpose
+                            We&apos;ll send an otp to this address for verification purpose
                         </Text>
                         <Box>
                             <TextInput value={email} label='Email Id' onChange={(e) => handleEmailChange(e.target.value)} />

--- a/frontend/ecommerce/src/app/(customer)/products/(components)/PlpFilters/CategoriesFilter.tsx
+++ b/frontend/ecommerce/src/app/(customer)/products/(components)/PlpFilters/CategoriesFilter.tsx
@@ -7,7 +7,7 @@ const CategoriesFilter = ({ categories, isMobile = false, handleClose }: { categ
     const searchParams = useSearchParams();
     const selectedCategory = searchParams.get('category');
 
-    const updateFilter = (value: any) => {
+    const updateFilter = (value: string) => {
         const params = new URLSearchParams(searchParams.toString());
         params.delete('variants');
         params.delete("page");

--- a/frontend/ecommerce/src/app/(customer)/products/(components)/PlpFilters/mobile/PlpMobileFilterTabs.tsx
+++ b/frontend/ecommerce/src/app/(customer)/products/(components)/PlpFilters/mobile/PlpMobileFilterTabs.tsx
@@ -173,7 +173,7 @@ export const PlpMobileFilterTab = ({ facets }: { facets: Record<string, FacetVal
                     </Tabs.List>
                 </ScrollArea>
                 {tabValues.map(t =>
-                    <Tabs.Panel value={t.value} style={{ padding: '14px', borderLeft: "1px solid var(--mantine-color-gray-2)" }}>
+                    <Tabs.Panel key={t.value} value={t.value} style={{ padding: '14px', borderLeft: "1px solid var(--mantine-color-gray-2)" }}>
                         <ScrollArea h={"300px"} style={{ overflow: "scroll" }}>
                             {t.Component}
                         </ScrollArea>

--- a/frontend/ecommerce/src/app/(customer)/products/(components)/PlpSorting.tsx
+++ b/frontend/ecommerce/src/app/(customer)/products/(components)/PlpSorting.tsx
@@ -47,7 +47,7 @@ const PlpSorting = ({ isMobile = false, handleClose }: { isMobile?: boolean; han
                     {sortingData.map(s => {
                         const Icon = s.icon;
                         return (
-                            <Group onClick={() => {
+                            <Group key={s.value} onClick={() => {
                                 updateParams(s.value);
                                 handleClose && handleClose();
                             }

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(address)/AddEditAddressForm.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(address)/AddEditAddressForm.tsx
@@ -131,6 +131,7 @@ const AddEditAddressForm = ({
                 <Group mt="xs">
                   {Object.values(AddressType).map((i) => (
                     <Radio
+                      key={i}
                       value={i}
                       label={i}
                       size="xs"

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(address)/AddressListSection.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(address)/AddressListSection.tsx
@@ -140,6 +140,7 @@ export const AddressListSection = ({
                 </Text>
                 {otherAddress.map((address) => (
                   <AddressCard
+                    key={address.addressId}
                     address={address}
                     showLoading={showLoading}
                     stopLoading={stopLoading}

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/(CartItemCard)/Quantity.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/(CartItemCard)/Quantity.tsx
@@ -131,6 +131,7 @@ const Quantity = ({
           {data.map((i) => {
             return (
               <Group
+                key={i}
                 gap={8}
                 py={4}
                 onClick={() => setValue(i)}

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/AddressListingForCart.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/AddressListingForCart.tsx
@@ -213,6 +213,7 @@ const AddressListingForCart = ({
               .filter((a) => !a.isDefault)
               .map((i) => (
                 <AddressCard
+                  key={i.addressId}
                   address={i}
                   selectedLocal={selectedLocal}
                   setSelectedLocal={setSelectedLocal}

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/PriceDetailsBox.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/(cart)/PriceDetailsBox.tsx
@@ -17,7 +17,6 @@ import { useEffect, useState } from "react";
 import { LoadingPrice } from "./LoadingCart";
 import { PriceDetailsBoxHelper } from "./PriceDetailsBoxHelper";
 import PriceDetailsBoxButton from "./(CartItemCard)/PriceDetailsBoxButton";
-import { useIsLoggedIn } from "@/utils/store/auth";
 
 const PriceDetailsBox = () => {
   const cartItems = useCartItems();
@@ -38,7 +37,6 @@ const PriceDetailsBox = () => {
     amountToAvoidShippingFee,
     payableAmount,
   } = priceSummary;
-  const isLoggedIn = useIsLoggedIn();
   const getTotalPrice = async () => {
     try {
       setIsLoading(true);
@@ -64,9 +62,9 @@ const PriceDetailsBox = () => {
   };
 
   useEffect(() => {
-    if (isLoggedIn)
+    if (selectedCartItems.length > 0)
       getTotalPrice();
-  }, [cartItems, selectedCouponCode, giftWrap, donationAmt, isLoggedIn]);
+  }, [cartItems, selectedCouponCode, giftWrap, donationAmt]);
 
   const { step } = useParams();
   return (

--- a/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/page.tsx
+++ b/frontend/ecommerce/src/app/(customer-checkout)/checkout/[step]/page.tsx
@@ -59,8 +59,8 @@ const Checkout = () => {
       if (isLoggedIn) {
         await updateOverallCartAction(updatedCart);
       }
-      let updatedCartOutOfStock: CartItemDTO[] = [];
-      let updatedCartInStock: CartItemDTO[] = [];
+      const updatedCartOutOfStock: CartItemDTO[] = [];
+      const updatedCartInStock: CartItemDTO[] = [];
       updatedCart.forEach((i) => {
         if (i.updatedQuantity === 0) {
           updatedCartOutOfStock.push(i);

--- a/frontend/ecommerce/src/constants/types.ts
+++ b/frontend/ecommerce/src/constants/types.ts
@@ -428,11 +428,11 @@ export interface FacetValue {
 }
 
 export interface saveUserDTO {
-  id: String;
-  name: String;
-  email: String;
+  id: string;
+  name: string;
+  email: string;
   emailVerified: boolean;
-  image: String;
+  image: string;
 }
 
 export interface User {

--- a/frontend/ecommerce/src/lib/apiFetch.ts
+++ b/frontend/ecommerce/src/lib/apiFetch.ts
@@ -47,11 +47,9 @@ export async function apiFetch<T>(
     };
   }
 
-  let res: Response;
-
   // console.log(`API Fetch: `, finalHeaders);
 
-  res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${endpoint}`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${endpoint}`, {
     method,
     headers: finalHeaders,
     body: body ? JSON.stringify(body) : undefined,

--- a/frontend/ecommerce/src/lib/refreshToken.ts
+++ b/frontend/ecommerce/src/lib/refreshToken.ts
@@ -37,7 +37,7 @@ function parseSetCookie(setCookie: string) {
   const [nameValue, ...attributes] = parts;
   const [name, value] = nameValue.split("=");
 
-  const options: any = {};
+  const options: Record<string, string> = {};
 
   attributes.forEach(attr => {
     const [key, val] = attr.split("=");


### PR DESCRIPTION
## Summary

- Removed the `isLoggedIn` guard from the price summary `useEffect` in `PriceDetailsBox.tsx` so guest users can fetch pricing from the public `/order-service/public/price-summary` endpoint
- Added an empty-cart guard (`selectedCartItems.length > 0`) to prevent unnecessary API calls
- Fixed 17 pre-existing lint errors across the frontend (missing `key` props, unescaped entities, `no-explicit-any`, `prefer-const`)

Closes #31

## Test plan

- [ ] Open app in incognito (guest user), add items to cart, verify pricing shows real totals
- [ ] Apply a coupon and verify discount reflects in price summary
- [ ] Toggle gift wrap and verify ₹35 fee appears
- [ ] Verify delivery charge shows ₹99 when total < ₹999, free when >= ₹999
- [ ] Log in and verify pricing still works for authenticated users (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)